### PR TITLE
Check if SerializationException is already declared

### DIFF
--- a/lib/Sync/functions.php
+++ b/lib/Sync/functions.php
@@ -5,7 +5,9 @@ namespace Amp\Parallel\Sync;
 use Amp\Serialization\SerializationException as SerializerException;
 
 // Alias must be defined in an always-loaded file as catch blocks do not trigger the autoloader.
-\class_alias(SerializerException::class, SerializationException::class);
+if (!class_exists(SerializationException::class, false)) {
+    \class_alias(SerializerException::class, SerializationException::class);
+}
 
 /**
  * @param \Throwable $exception


### PR DESCRIPTION
Trying to declare an alias for a class that is already declared in the runtime will lead to
a warning. Checking for the presence of the class avoids that.

This fixes warnings that are raised when opcache preloading is enabled. The fix is suggested e.g. [here](https://github.com/symfony/symfony/issues/39961#issuecomment-855038757).

With this change I no longer get warnings in my project. These [are indeed only warnings](https://github.com/symfony/symfony/issues/43308#issuecomment-945060366) that can be ignored so no functional changes should be introduced with this PR.

Fixes #145 .