### PR TITLE
Only throw ContextException from receive, send, and join

### DIFF
--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -16,8 +16,7 @@ interface Context extends Channel
     /**
      * @return TResult The data returned from the context.
      *
-     * @throws ContextException If the context dies unexpectedly.
-     * @throws ContextPanicError If the context throws an uncaught exception.
+     * @throws ContextException If the context exited with an uncaught exception or non-zero code.
      */
     public function join(?Cancellation $cancellation = null): mixed;
 }

--- a/src/Context/Internal/AbstractContext.php
+++ b/src/Context/Internal/AbstractContext.php
@@ -24,8 +24,6 @@ abstract class AbstractContext implements Context
     use ForbidCloning;
     use ForbidSerialization;
 
-    private ?ExitResult $result = null;
-
     protected function __construct(
         private readonly Channel $channel,
     ) {
@@ -43,24 +41,23 @@ abstract class AbstractContext implements Context
                     $this->close();
                 }
                 throw new ContextException(
-                    "The process stopped responding, potentially due to a fatal error or calling exit",
+                    "The context stopped responding, potentially due to a fatal error or calling exit",
                     previous: $exception,
                 );
             }
 
             throw new ContextException(\sprintf(
-                'Process unexpectedly exited when waiting to receive data with result: %s',
+                'Context unexpectedly exited when waiting to receive data with result: %s',
                 flattenArgument($data),
             ), previous: $exception);
         }
 
         if (!$data instanceof ContextMessage) {
             if ($data instanceof ExitResult) {
-                $this->result = $data;
                 $data = $data->getResult();
 
                 throw new ContextException(\sprintf(
-                    'Process unexpectedly exited when waiting to receive data with result: %s',
+                    'Context unexpectedly exited when waiting to receive data with result: %s',
                     flattenArgument($data),
                 ));
             }
@@ -87,13 +84,13 @@ abstract class AbstractContext implements Context
                 }
 
                 throw new ContextException(
-                    "The process stopped responding, potentially due to a fatal error or calling exit",
+                    "The context stopped responding, potentially due to a fatal error or calling exit",
                     previous: $exception,
                 );
             }
 
             throw new ContextException(\sprintf(
-                'Process unexpectedly exited when sending data with result: %s',
+                'Context unexpectedly exited when sending data with result: %s',
                 flattenArgument($data),
             ), 0, $exception);
         }
@@ -116,10 +113,6 @@ abstract class AbstractContext implements Context
 
     protected function receiveExitResult(?Cancellation $cancellation = null): ExitResult
     {
-        if ($this->result) {
-            return $this->result;
-        }
-
         if ($this->channel->isClosed()) {
             throw new ContextException("The context has already closed without providing a result");
         }
@@ -151,7 +144,6 @@ abstract class AbstractContext implements Context
         }
 
         $this->channel->close();
-        $this->result = $data;
 
         return $data;
     }

--- a/src/Context/Internal/ExitFailure.php
+++ b/src/Context/Internal/ExitFailure.php
@@ -2,6 +2,7 @@
 
 namespace Amp\Parallel\Context\Internal;
 
+use Amp\Parallel\Context\ContextException;
 use Amp\Parallel\Context\ContextPanicError;
 use function Amp\Parallel\Context\flattenThrowableBacktrace;
 
@@ -42,11 +43,16 @@ final class ExitFailure implements ExitResult
     }
 
     /**
-     * @throws ContextPanicError
+     * @throws ContextException
      */
     public function getResult(): never
     {
-        throw $this->createException();
+        $exception = $this->createException();
+
+        throw new ContextException(
+            'Process exited with an uncaught exception: ' . $exception->getMessage(),
+            previous: $exception,
+        );
     }
 
     private function createException(): ContextPanicError

--- a/src/Context/Internal/ExitResult.php
+++ b/src/Context/Internal/ExitResult.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Parallel\Context\Internal;
 
-use Amp\Parallel\Context\ContextPanicError;
+use Amp\Parallel\Context\ContextException;
 
 /**
  * @internal
@@ -13,7 +13,7 @@ interface ExitResult
     /**
      * @return TValue Return value of the callable given to the execution context.
      *
-     * @throws ContextPanicError If the context exited with an uncaught exception.
+     * @throws ContextException If the context exited with an uncaught exception.
      */
     public function getResult(): mixed;
 }

--- a/test/Context/AbstractContextTest.php
+++ b/test/Context/AbstractContextTest.php
@@ -41,28 +41,21 @@ abstract class AbstractContextTest extends AsyncTestCase
 
         $cancellation = new TimeoutCancellation(0.1);
 
-        try {
-            $context->receive($cancellation);
-            self::fail('Receiving should have failed');
-        } catch (ContextException) {
-            $context->join($cancellation);
-        }
+        $context->receive($cancellation);
+
+        self::fail('Receiving should have failed');
     }
 
     public function testThrowingProcessOnSend(): void
     {
         $this->expectException(ContextException::class);
-        $this->expectExceptionMessage('Test message');
 
         $context = $this->createContext(__DIR__ . "/Fixtures/throwing-process.php");
-        delay(1);
+        delay(1); // Give process time to start.
 
-        try {
-            $context->send(1);
-            self::fail('Sending should have failed');
-        } catch (ContextException) {
-            $context->join(new TimeoutCancellation(1));
-        }
+        $context->send(1);
+
+        self::fail('Sending should have failed');
     }
 
     public function testInvalidScriptPath(): void

--- a/test/Context/AbstractContextTest.php
+++ b/test/Context/AbstractContextTest.php
@@ -5,7 +5,6 @@ namespace Amp\Parallel\Test\Context;
 use Amp\CancelledException;
 use Amp\Parallel\Context\Context;
 use Amp\Parallel\Context\ContextException;
-use Amp\Parallel\Context\ContextPanicError;
 use Amp\PHPUnit\AsyncTestCase;
 use Amp\TimeoutCancellation;
 use function Amp\async;
@@ -26,7 +25,7 @@ abstract class AbstractContextTest extends AsyncTestCase
 
     public function testFailingProcess(): void
     {
-        $this->expectException(ContextPanicError::class);
+        $this->expectException(ContextException::class);
         $this->expectExceptionMessage('No string provided');
 
         $context = $this->createContext(__DIR__ . "/Fixtures/test-process.php");
@@ -35,7 +34,7 @@ abstract class AbstractContextTest extends AsyncTestCase
 
     public function testThrowingProcessOnReceive(): void
     {
-        $this->expectException(ContextPanicError::class);
+        $this->expectException(ContextException::class);
         $this->expectExceptionMessage('Test message');
 
         $context = $this->createContext(__DIR__ . "/Fixtures/throwing-process.php");
@@ -52,7 +51,7 @@ abstract class AbstractContextTest extends AsyncTestCase
 
     public function testThrowingProcessOnSend(): void
     {
-        $this->expectException(ContextPanicError::class);
+        $this->expectException(ContextException::class);
         $this->expectExceptionMessage('Test message');
 
         $context = $this->createContext(__DIR__ . "/Fixtures/throwing-process.php");
@@ -68,7 +67,7 @@ abstract class AbstractContextTest extends AsyncTestCase
 
     public function testInvalidScriptPath(): void
     {
-        $this->expectException(ContextPanicError::class);
+        $this->expectException(ContextException::class);
         $this->expectExceptionMessage("No script found at '../test-process.php'");
 
         $context = $this->createContext("../test-process.php");
@@ -77,7 +76,7 @@ abstract class AbstractContextTest extends AsyncTestCase
 
     public function testInvalidResult(): void
     {
-        $this->expectException(ContextPanicError::class);
+        $this->expectException(ContextException::class);
         $this->expectExceptionMessage('The given data could not be serialized');
 
         $context = $this->createContext(__DIR__ . "/Fixtures/invalid-result-process.php");
@@ -86,7 +85,7 @@ abstract class AbstractContextTest extends AsyncTestCase
 
     public function testNoCallbackReturned(): void
     {
-        $this->expectException(ContextPanicError::class);
+        $this->expectException(ContextException::class);
         $this->expectExceptionMessage('did not return a callable function');
 
         $context = $this->createContext(__DIR__ . "/Fixtures/no-callback-process.php");
@@ -95,7 +94,7 @@ abstract class AbstractContextTest extends AsyncTestCase
 
     public function testParseError(): void
     {
-        $this->expectException(ContextPanicError::class);
+        $this->expectException(ContextException::class);
         $this->expectExceptionMessage('contains a parse error');
 
         $context = $this->createContext(__DIR__ . "/Fixtures/parse-error-process.inc");

--- a/test/Context/Internal/ExitFailureTest.php
+++ b/test/Context/Internal/ExitFailureTest.php
@@ -2,7 +2,7 @@
 
 namespace Amp\Parallel\Test\Context\Internal;
 
-use Amp\Parallel\Context\ContextPanicError;
+use Amp\Parallel\Context\ContextException;
 use Amp\Parallel\Context\Internal\ExitFailure;
 use Amp\PHPUnit\AsyncTestCase;
 
@@ -15,7 +15,7 @@ class ExitFailureTest extends AsyncTestCase
         $result = new ExitFailure($exception);
         try {
             $result->getResult();
-        } catch (ContextPanicError $caught) {
+        } catch (ContextException $caught) {
             self::assertGreaterThan(0, \stripos($caught->getMessage(), $message));
             return;
         }


### PR DESCRIPTION
This avoids throwing `ContextPanicError` directly from these methods, instead throwing `ContextException` with `ContextPanicError` as the previous exception.

This should be BC since these methods were documented as throwing `ContextException`.