### PR TITLE
Include context backtrace in message

### DIFF
--- a/src/Context/Internal/ContextException.php
+++ b/src/Context/Internal/ContextException.php
@@ -26,9 +26,7 @@ trait ContextException
         ?\Throwable $previous = null,
     ) {
         $format = '%s thrown in context with message "%s" and code "%s" in %s:%d'
-            . '; call %s::getOriginalTrace() for the stack trace in the context as an array;'
-            . ' if the Xdebug extension is enabled, set "xdebug.mode" to "debug" to include'
-            . ' the exception stack trace in the context in the exception message';
+            . "\nStack trace in context:\n%s" ;
 
         parent::__construct(\sprintf(
             $format,
@@ -37,13 +35,8 @@ trait ContextException
             $originalCode,
             $originalFile,
             $originalLine,
-            self::class,
+            $this->getOriginalTraceAsString(),
         ), previous: $previous);
-    }
-
-    public function __toString(): string
-    {
-        return \sprintf("%s\nStack trace in context:\n%s", $this->getMessage(), $this->getOriginalTraceAsString());
     }
 
     /**


### PR DESCRIPTION
PHP does not call `__toString()` on a previous exception, so our decision to wrap `ContextPanicError` in a `ContextException` had the unfortunate side-effect of removing the context trace from the output of an uncaught exception.

There's a couple ways we can approach this. This PR puts the trace as a string into the message. This has the side-effect of needing to create a stack-trace string for uncaught exceptions from `Tasks`, but is mostly negligible I'd think.

Another approach would be to use reflection to set the `$trace` property of the parent exception, forcing the child trace to be the trace of the `ContextPanicError` object.

```php
(new \ReflectionProperty(parent::class, 'trace'))->setValue($this, $originalTrace);
```