### PR TITLE
Add previous exception message when fail to start process

### DIFF
--- a/src/Context/ProcessContext.php
+++ b/src/Context/ProcessContext.php
@@ -152,7 +152,7 @@ final class ProcessContext extends AbstractContext
         try {
             $process = Process::start($command, $workingDirectory, $environment);
         } catch (\Throwable $exception) {
-            throw new ContextException("Starting the process failed", 0, $exception);
+            throw new ContextException("Starting the process failed: " . $exception->getMessage(), 0, $exception);
         }
 
         try {


### PR DESCRIPTION
Really not sure about this, but I see you do it around the codebase with ContextException. 

An alternative would be 

```php
throw new ContextException(
    sprintf("Starting the process failed (%s)", $exception->getMessage()), 
    previous: $exception
);
```

Next step would be a small API for ContextException itself? 