### PR TITLE
Small improvements on examples

### DIFF
--- a/examples/context.php
+++ b/examples/context.php
@@ -20,9 +20,9 @@ try {
     print "Waiting 2 seconds to send start data...\n";
     delay(2);
 
-    $context->send("Start data"); // Data sent to child process, received on line 9 of blocking-process.php
+    $context->send("Start data"); // Data sent to child process, received on line 9 of contexts/blocking.php
 
-    printf("Received the following from child: %s\n", $context->receive()); // Sent on line 14 of blocking-process.php
+    printf("Received the following from child: %s\n", $context->receive()); // Sent on line 14 of blocking.php
     printf("Process ended with value %d!\n", $context->join());
 } finally {
     EventLoop::cancel($timer);

--- a/examples/context.php
+++ b/examples/context.php
@@ -9,7 +9,8 @@ use function Amp\Parallel\Context\contextFactory;
 $timer = EventLoop::repeat(1, function () {
     static $i;
     $i = $i ? ++$i : 1;
-    print "Demonstrating how alive the parent is for the {$i}th time.\n";
+    $nth = $i . ([1 => 'st', 2 => 'nd', 3 => 'rd'][$i] ?? 'th');
+    print "Demonstrating how alive the parent is for the {$nth} time.\n";
 });
 
 try {

--- a/examples/process.php
+++ b/examples/process.php
@@ -28,9 +28,9 @@ try {
     print "Waiting 2 seconds to send start data...\n";
     delay(2);
 
-    $context->send("Start data"); // Data sent to child process, received on line 9 of blocking-process.php
+    $context->send("Start data"); // Data sent to child process, received on line 9 of contexts/blocking.php
 
-    printf("Received the following from child: %s\n", $context->receive()); // Sent on line 14 of blocking-process.php
+    printf("Received the following from child: %s\n", $context->receive()); // Sent on line 14 of contexts/blocking.php
     printf("Process ended with value %d!\n", $context->join());
 } finally {
     EventLoop::cancel($timer);

--- a/examples/process.php
+++ b/examples/process.php
@@ -11,7 +11,8 @@ use function Amp\delay;
 $timer = EventLoop::repeat(1, function () {
     static $i;
     $i = $i ? ++$i : 1;
-    print "Demonstrating how alive the parent is for the {$i}th time.\n";
+    $nth = $i . ([1 => 'st', 2 => 'nd', 3 => 'rd'][$i] ?? 'th');
+    print "Demonstrating how alive the parent is for the {$nth} time.\n";
 });
 
 // This example is identical to context.php, but uses a ProcessContext to demonstrate piping STDOUT


### PR DESCRIPTION
Shows output like so now:

```sh
➜  parallel git:(7b53bad) ✗ php examples/context.php
Waiting 2 seconds to send start data...
Demonstrating how alive the parent is for the 1st time.
Demonstrating how alive the parent is for the 2nd time.
Received the following from parent: Start data
Sleeping for 3 seconds...
Demonstrating how alive the parent is for the 3rd time.
Demonstrating how alive the parent is for the 4th time.
Demonstrating how alive the parent is for the 5th time.
Received the following from child: Data sent from child.
Sleeping for 2 seconds...
Demonstrating how alive the parent is for the 6th time.
Demonstrating how alive the parent is for the 7th time.
Process ended with value 42!

➜  parallel git:(7b53bad) ✗ php examples/process.php                   
Waiting 2 seconds to send start data...
Demonstrating how alive the parent is for the 1st time.
Demonstrating how alive the parent is for the 2nd time.
Received the following from parent: Start data
Sleeping for 3 seconds...
Demonstrating how alive the parent is for the 3rd time.
Demonstrating how alive the parent is for the 4th time.
Demonstrating how alive the parent is for the 5th time.
Received the following from child: Data sent from child.
Sleeping for 2 seconds...
Demonstrating how alive the parent is for the 6th time.
Demonstrating how alive the parent is for the 7th time.
Process ended with value 42!
```
