### PR TITLE
Add LimitedWorkerPool

### DIFF
--- a/src/Worker/ContextWorkerPool.php
+++ b/src/Worker/ContextWorkerPool.php
@@ -20,7 +20,7 @@ use function Amp\async;
  * tasks simultaneously. The load on each worker is balanced such that tasks
  * are completed as soon as possible and workers are used efficiently.
  */
-final class ContextWorkerPool implements WorkerPool
+final class ContextWorkerPool implements LimitedWorkerPool
 {
     use ForbidCloning;
     use ForbidSerialization;
@@ -104,14 +104,21 @@ final class ContextWorkerPool implements WorkerPool
         return $this->idleWorkers->count() > 0 || $this->workers->count() < $this->limit;
     }
 
+    public function getWorkerLimit(): int
+    {
+        return $this->limit;
+    }
+
     /**
      * Gets the maximum number of workers the pool may spawn to handle concurrent tasks.
      *
      * @return int The maximum number of workers.
+     *
+     * @deprecated Use {@see getWorkerLimit()} instead.
      */
     public function getLimit(): int
     {
-        return $this->limit;
+        return $this->getWorkerLimit();
     }
 
     public function getWorkerCount(): int

--- a/src/Worker/DelegatingWorkerPool.php
+++ b/src/Worker/DelegatingWorkerPool.php
@@ -4,10 +4,15 @@ namespace Amp\Parallel\Worker;
 
 use Amp\Cancellation;
 use Amp\DeferredFuture;
+use Amp\ForbidCloning;
+use Amp\ForbidSerialization;
 use Amp\Parallel\Worker\Internal\PooledWorker;
 
-final class DelegatingWorkerPool implements WorkerPool
+final class DelegatingWorkerPool implements LimitedWorkerPool
 {
+    use ForbidCloning;
+    use ForbidSerialization;
+
     /** @var array<int, Worker> */
     private array $workerStorage = [];
 
@@ -116,7 +121,7 @@ final class DelegatingWorkerPool implements WorkerPool
         return new PooledWorker($this->selectWorker(), $this->push(...));
     }
 
-    public function getLimit(): int
+    public function getWorkerLimit(): int
     {
         return $this->limit;
     }

--- a/src/Worker/LimitedWorkerPool.php
+++ b/src/Worker/LimitedWorkerPool.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Amp\Parallel\Worker;
+
+interface LimitedWorkerPool extends WorkerPool
+{
+    /**
+     * Gets the maximum number of workers the pool may spawn to handle concurrent tasks.
+     *
+     * @return int The maximum number of workers.
+     */
+    public function getWorkerLimit(): int;
+}


### PR DESCRIPTION
This adds a new interface, `LimitedWorkerPool`, which extends the existing `WorkerPool` adding a method to get the maximum number of workers available in the pool.