### PR TITLE
Prevent silencing ExitFailure in ProcessContext->join()

### DIFF
--- a/src/Context/ProcessContext.php
+++ b/src/Context/ProcessContext.php
@@ -7,6 +7,7 @@ use Amp\ByteStream\StreamChannel;
 use Amp\ByteStream\WritableResourceStream;
 use Amp\Cancellation;
 use Amp\Parallel\Context\Internal\AbstractContext;
+use Amp\Parallel\Context\Internal\ExitFailure;
 use Amp\Parallel\Ipc\IpcHub;
 use Amp\Process\Process;
 use Amp\Process\ProcessException;
@@ -281,7 +282,7 @@ final class ProcessContext extends AbstractContext
         $data = $this->receiveExitResult($cancellation);
 
         $code = $this->process->join();
-        if ($code !== 0) {
+        if ($code !== 0 && !($data instanceof ExitFailure)) {
             throw new ContextException(\sprintf("Context exited with code %d", $code));
         }
 

--- a/src/Context/ProcessContext.php
+++ b/src/Context/ProcessContext.php
@@ -7,7 +7,6 @@ use Amp\ByteStream\StreamChannel;
 use Amp\ByteStream\WritableResourceStream;
 use Amp\Cancellation;
 use Amp\Parallel\Context\Internal\AbstractContext;
-use Amp\Parallel\Context\Internal\ExitFailure;
 use Amp\Parallel\Ipc\IpcHub;
 use Amp\Process\Process;
 use Amp\Process\ProcessException;

--- a/src/Context/ProcessContext.php
+++ b/src/Context/ProcessContext.php
@@ -282,11 +282,16 @@ final class ProcessContext extends AbstractContext
         $data = $this->receiveExitResult($cancellation);
 
         $code = $this->process->join();
-        if ($code !== 0 && !($data instanceof ExitFailure)) {
-            throw new ContextException(\sprintf("Context exited with code %d", $code));
-        }
 
-        return $data->getResult();
+        try {
+            return $data->getResult();
+        } finally {
+            if ($code !== 0) {
+                // If an ExitFailure throws above, the exception will be automatically attached as the previous
+                // exception on the instance thrown below.
+                throw new ContextException(\sprintf("Context exited with code %d", $code));
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
If there was an ExitSuccess, it's expected to be 0. If no failure was present, then the exit code is the only thing to be reported.

But, if there was an ExitFailure, and the process did not cleanly exit, the failure most likely was the cause of the unclean exit and should be reported in any case.

I'm not sure whether returning or throwing is the best course of action, but possibly we should throw the failure after .. the join() call.