### PR TITLE
Add ForkContext

### DIFF
--- a/composer-require-check.json
+++ b/composer-require-check.json
@@ -39,6 +39,7 @@
         "SPL",
         "standard",
         "hash",
-        "pcntl"
+        "pcntl",
+        "posix"
     ]
 }

--- a/src/Context/ForkContext.php
+++ b/src/Context/ForkContext.php
@@ -12,7 +12,7 @@ use Amp\TimeoutCancellation;
 
 /**
  * USE AT YOUR OWN RISK! This context is not used by default in {@see DefaultContextFactory} because the timing of its
- * use must be purposeful and situational.
+ * creation must be purposeful and situational.
  *
  * Forking is not recommended at arbitrary points in an application since the entire state of the parent process is
  * inherited into the child process, including the event-loop!
@@ -83,7 +83,9 @@ final class ForkContext extends AbstractContext
         exit(0);
     }
 
-    private bool $exited = false;
+    private ?int $exited = null;
+
+    private bool $weKilled = false;
 
     /**
      * @param StreamChannel<TReceive, TSend> $ipcChannel
@@ -101,11 +103,49 @@ final class ForkContext extends AbstractContext
         $this->close();
     }
 
+    public function receive(?Cancellation $cancellation = null): mixed
+    {
+        $this->checkExit(false);
+
+        return parent::receive($cancellation);
+    }
+
+    public function send(mixed $data): void
+    {
+        $this->checkExit(false);
+
+        parent::send($data);
+    }
+
+    private function checkExit(bool $wait): ?int
+    {
+        if ($this->exited === null) {
+            if (\pcntl_waitpid($this->pid, $status, $wait ? 0 : \WNOHANG) === 0) {
+                return null;
+            }
+
+            $this->exited = match (true) {
+                \pcntl_wifsignaled($status) => \pcntl_wtermsig($status),
+                \pcntl_wifexited($status) => \pcntl_wexitstatus($status) - 128,
+                \pcntl_wifstopped($status) => \pcntl_wstopsig($status),
+                default => -1,
+            };
+        }
+
+        if (!$this->weKilled && $this->exited > 0) {
+            throw new ContextException("Worker exited due to signal {$this->exited}", $this->exited);
+        }
+
+        return $this->exited;
+    }
+
     public function close(): void
     {
         if (!$this->exited) {
+            $this->weKilled = true;
             \posix_kill($this->pid, \SIGKILL);
-            $this->exited = true;
+
+            $this->checkExit(true);
         }
 
         parent::close();
@@ -113,9 +153,11 @@ final class ForkContext extends AbstractContext
 
     public function join(?Cancellation $cancellation = null): mixed
     {
-        $data = $this->receiveExitResult($cancellation);
-
-        $this->close();
+        try {
+            $data = $this->receiveExitResult($cancellation);
+        } finally {
+            $this->close();
+        }
 
         return $data->getResult();
     }

--- a/src/Context/ForkContext.php
+++ b/src/Context/ForkContext.php
@@ -78,7 +78,7 @@ final class ForkContext extends AbstractContext
         }
 
         // Child
-        \define("AMP_CONTEXT", "parallel");
+        \define("AMP_CONTEXT", "fork");
         \define("AMP_CONTEXT_ID", \getmypid());
 
         if (\is_string($script)) {

--- a/src/Context/ForkContext.php
+++ b/src/Context/ForkContext.php
@@ -9,7 +9,6 @@ use Amp\Parallel\Ipc\IpcHub;
 use Amp\Serialization\NativeSerializer;
 use Amp\Serialization\Serializer;
 use Amp\TimeoutCancellation;
-use React\EventLoop\StreamSelectLoop;
 use Revolt\EventLoop;
 
 /**
@@ -34,7 +33,7 @@ final class ForkContext extends AbstractContext
 
     public static function isSupported(): bool
     {
-        return \function_exists('pcntl_fork') && EventLoop::getDriver() instanceof StreamSelectLoop;
+        return \function_exists('pcntl_fork') && EventLoop::getDriver()->getHandle() === null;
     }
 
     /**

--- a/src/Context/ForkContext.php
+++ b/src/Context/ForkContext.php
@@ -157,8 +157,8 @@ final class ForkContext extends AbstractContext
 
     public function join(?Cancellation $cancellation = null): mixed
     {
-        $data = $this->receiveExitResult($cancellation);
+        $result = $this->receiveExitResult($cancellation);
 
-        return $data->getResult();
+        return $result->getResult();
     }
 }

--- a/src/Context/ForkContext.php
+++ b/src/Context/ForkContext.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+namespace Amp\Parallel\Context;
+
+use Amp\ByteStream\StreamChannel;
+use Amp\Cancellation;
+use Amp\Parallel\Context\Internal\AbstractContext;
+use Amp\Parallel\Ipc\IpcHub;
+use Amp\Serialization\NativeSerializer;
+use Amp\Serialization\Serializer;
+use Amp\TimeoutCancellation;
+
+/**
+ * USE AT YOUR OWN RISK! This context is not used by default in {@see DefaultContextFactory} because the timing of its
+ * use must be purposeful and situational.
+ *
+ * Forking is not recommended at arbitrary points in an application since the entire state of the parent process is
+ * inherited into the child process, including the event-loop!
+ *
+ * Forking very early in an application, may be beneficial to copy state from the parent that was expensive to set up.
+ *
+ * This context is NOT compatible with event-loop extensions such as ext-uv or ext-ev.
+ *
+ * @template-covariant TResult
+ * @template-covariant TReceive
+ * @template TSend
+ * @extends AbstractContext<TResult, TReceive, TSend>
+ */
+final class ForkContext extends AbstractContext
+{
+    private const DEFAULT_START_TIMEOUT = 5;
+
+    /**
+     * @param string|non-empty-list<string> $script Path to PHP script or array with first element as path and
+     *     following elements options to the PHP script (e.g.: ['bin/worker.php', 'Option1Value', 'Option2Value']).
+     * @param positive-int $childConnectTimeout Number of seconds the child will attempt to connect to the parent
+     *      before failing.
+     *
+     * @throws ContextException If starting the process fails.
+     */
+    public static function start(
+        IpcHub $ipcHub,
+        string|array $script,
+        ?Cancellation $cancellation = null,
+        int $childConnectTimeout = self::DEFAULT_START_TIMEOUT,
+        Serializer $serializer = new NativeSerializer(),
+    ): self {
+        $key = $ipcHub->generateKey();
+
+        // Fork
+        if (($pid = \pcntl_fork()) < 0) {
+            throw new ContextException("Forking failed: " . \posix_strerror(\posix_get_last_error()));
+        }
+
+        // Parent
+        if ($pid > 0) {
+            try {
+                $socket = $ipcHub->accept($key, $cancellation);
+                $ipcChannel = new StreamChannel($socket, $socket, $serializer);
+
+                $socket = $ipcHub->accept($key, $cancellation);
+                $resultChannel = new StreamChannel($socket, $socket, $serializer);
+            } catch (\Throwable $exception) {
+                $cancellation?->throwIfRequested();
+
+                throw new ContextException("Connecting failed after forking", previous: $exception);
+            }
+
+            return new self($pid, $ipcChannel, $resultChannel);
+        }
+
+        // Child
+        \define("AMP_CONTEXT", "parallel");
+        \define("AMP_CONTEXT_ID", \getmypid());
+
+        if (\is_string($script)) {
+            $script = [$script];
+        }
+
+        $connectCancellation = new TimeoutCancellation((float) $childConnectTimeout);
+        Internal\runContext($ipcHub->getUri(), $key, $connectCancellation, $script, $serializer);
+
+        exit(0);
+    }
+
+    private bool $exited = false;
+
+    /**
+     * @param StreamChannel<TReceive, TSend> $ipcChannel
+     */
+    private function __construct(
+        private readonly int $pid,
+        StreamChannel $ipcChannel,
+        StreamChannel $resultChannel,
+    ) {
+        parent::__construct($ipcChannel, $resultChannel);
+    }
+
+    public function __destruct()
+    {
+        $this->close();
+    }
+
+    public function close(): void
+    {
+        if (!$this->exited) {
+            \posix_kill($this->pid, \SIGKILL);
+            $this->exited = true;
+        }
+
+        parent::close();
+    }
+
+    public function join(?Cancellation $cancellation = null): mixed
+    {
+        $data = $this->receiveExitResult($cancellation);
+
+        $this->close();
+
+        return $data->getResult();
+    }
+}

--- a/src/Context/ForkContext.php
+++ b/src/Context/ForkContext.php
@@ -11,7 +11,6 @@ use Amp\Serialization\Serializer;
 use Amp\TimeoutCancellation;
 use React\EventLoop\StreamSelectLoop;
 use Revolt\EventLoop;
-use Revolt\EventLoop\Driver\UvDriver;
 
 /**
  * USE AT YOUR OWN RISK! This context is not used by default in {@see DefaultContextFactory} because the timing of its

--- a/src/Context/ForkContext.php
+++ b/src/Context/ForkContext.php
@@ -141,7 +141,7 @@ final class ForkContext extends AbstractContext
 
     public function close(): void
     {
-        if (!$this->exited) {
+        if ($this->checkExit(false) === null) {
             $this->weKilled = true;
             \posix_kill($this->pid, \SIGKILL);
 

--- a/src/Context/ForkContext.php
+++ b/src/Context/ForkContext.php
@@ -33,7 +33,10 @@ final class ForkContext extends AbstractContext
 
     public static function isSupported(): bool
     {
-        return \function_exists('pcntl_fork') && EventLoop::getDriver()->getHandle() === null;
+        return \extension_loaded('pcntl')
+            && \extension_loaded('posix')
+            && \function_exists('pcntl_fork') // pcntl_fork may be disabled.
+            && EventLoop::getDriver()->getHandle() === null;
     }
 
     /**
@@ -102,11 +105,6 @@ final class ForkContext extends AbstractContext
         StreamChannel $resultChannel,
     ) {
         parent::__construct($ipcChannel, $resultChannel);
-    }
-
-    public function __destruct()
-    {
-        $this->close();
     }
 
     public function receive(?Cancellation $cancellation = null): mixed

--- a/src/Context/ForkContext.php
+++ b/src/Context/ForkContext.php
@@ -9,6 +9,7 @@ use Amp\Parallel\Ipc\IpcHub;
 use Amp\Serialization\NativeSerializer;
 use Amp\Serialization\Serializer;
 use Amp\TimeoutCancellation;
+use React\EventLoop\StreamSelectLoop;
 use Revolt\EventLoop;
 use Revolt\EventLoop\Driver\UvDriver;
 
@@ -34,8 +35,7 @@ final class ForkContext extends AbstractContext
 
     public static function isSupported(): bool
     {
-        return \function_exists('pcntl_fork')
-            && !EventLoop::getDriver() instanceof UvDriver;
+        return \function_exists('pcntl_fork') && EventLoop::getDriver() instanceof StreamSelectLoop;
     }
 
     /**

--- a/src/Context/ForkContext.php
+++ b/src/Context/ForkContext.php
@@ -30,6 +30,11 @@ final class ForkContext extends AbstractContext
 {
     private const DEFAULT_START_TIMEOUT = 5;
 
+    public static function isSupported(): bool
+    {
+        return \function_exists('pcntl_fork');
+    }
+
     /**
      * @param string|non-empty-list<string> $script Path to PHP script or array with first element as path and
      *     following elements options to the PHP script (e.g.: ['bin/worker.php', 'Option1Value', 'Option2Value']).
@@ -153,11 +158,9 @@ final class ForkContext extends AbstractContext
 
     public function join(?Cancellation $cancellation = null): mixed
     {
-        try {
-            $data = $this->receiveExitResult($cancellation);
-        } finally {
-            $this->close();
-        }
+        $data = $this->receiveExitResult($cancellation);
+
+        $this->close();
 
         return $data->getResult();
     }

--- a/src/Context/ForkContext.php
+++ b/src/Context/ForkContext.php
@@ -9,6 +9,8 @@ use Amp\Parallel\Ipc\IpcHub;
 use Amp\Serialization\NativeSerializer;
 use Amp\Serialization\Serializer;
 use Amp\TimeoutCancellation;
+use Revolt\EventLoop;
+use Revolt\EventLoop\Driver\UvDriver;
 
 /**
  * USE AT YOUR OWN RISK! This context is not used by default in {@see DefaultContextFactory} because the timing of its
@@ -32,7 +34,8 @@ final class ForkContext extends AbstractContext
 
     public static function isSupported(): bool
     {
-        return \function_exists('pcntl_fork');
+        return \function_exists('pcntl_fork')
+            && !EventLoop::getDriver() instanceof UvDriver;
     }
 
     /**

--- a/src/Context/ForkContext.php
+++ b/src/Context/ForkContext.php
@@ -111,14 +111,14 @@ final class ForkContext extends AbstractContext
 
     public function receive(?Cancellation $cancellation = null): mixed
     {
-        $this->checkExit(false);
+        $this->checkExit(false); // Will throw if the process exited unexpectedly.
 
         return parent::receive($cancellation);
     }
 
     public function send(mixed $data): void
     {
-        $this->checkExit(false);
+        $this->checkExit(false); // Will throw if the process exited unexpectedly.
 
         parent::send($data);
     }

--- a/src/Context/ForkContext.php
+++ b/src/Context/ForkContext.php
@@ -159,8 +159,6 @@ final class ForkContext extends AbstractContext
     {
         $data = $this->receiveExitResult($cancellation);
 
-        $this->close();
-
         return $data->getResult();
     }
 }

--- a/src/Context/ForkContextFactory.php
+++ b/src/Context/ForkContextFactory.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Amp\Parallel\Context;
+
+use Amp\Cancellation;
+use Amp\ForbidCloning;
+use Amp\ForbidSerialization;
+use Amp\Parallel\Ipc\IpcHub;
+use Amp\Parallel\Ipc\LocalIpcHub;
+
+/**
+ * USE AT YOUR OWN RISK!
+ *
+ * Forking is not recommended at arbitrary points in an application since the entire state of the parent process is
+ * inherited into the child process, including the event-loop!
+ *
+ * We recommend using {@see DefaultContextFactory} or {@see ProcessContextFactory} for general-purpose applications.
+ */
+final class ForkContextFactory implements ContextFactory
+{
+    use ForbidCloning;
+    use ForbidSerialization;
+
+    /**
+     * @param positive-int $childConnectTimeout Number of seconds the child will attempt to connect to the parent
+     *      before failing.
+     * @param IpcHub $ipcHub Optional IpcHub instance.
+     */
+    public function __construct(
+        private readonly int $childConnectTimeout = 5,
+        private readonly IpcHub $ipcHub = new LocalIpcHub(),
+    ) {
+    }
+
+    /**
+     * @param string|non-empty-list<string> $script
+     *
+     * @throws ContextException
+     */
+    public function start(string|array $script, ?Cancellation $cancellation = null): ForkContext
+    {
+        return ForkContext::start(
+            ipcHub: $this->ipcHub,
+            script: $script,
+            cancellation: $cancellation,
+            childConnectTimeout: $this->childConnectTimeout,
+        );
+    }
+}

--- a/src/Context/Internal/AbstractContext.php
+++ b/src/Context/Internal/AbstractContext.php
@@ -42,7 +42,7 @@ abstract class AbstractContext implements Context
             $this->ipcChannel->close();
 
             throw new ContextException(
-                "The context stopped responding, potentially due to a fatal error or calling exit",
+                "The context stopped responding during receive, potentially due to a fatal error or calling exit",
                 previous: $exception,
             );
         }
@@ -74,7 +74,7 @@ abstract class AbstractContext implements Context
             $this->ipcChannel->close();
 
             throw new ContextException(
-                "The context stopped responding, potentially due to a fatal error or calling exit",
+                "The context stopped responding during send, potentially due to a fatal error or calling exit",
                 previous: $exception,
             );
         }

--- a/src/Context/Internal/functions.php
+++ b/src/Context/Internal/functions.php
@@ -6,22 +6,29 @@ use Amp\ByteStream\StreamChannel;
 use Amp\Cancellation;
 use Amp\Future;
 use Amp\Parallel\Ipc;
+use Amp\Serialization\NativeSerializer;
 use Amp\Serialization\SerializationException;
+use Amp\Serialization\Serializer;
 use Revolt\EventLoop;
 
 /** @internal */
-function runContext(string $uri, string $key, Cancellation $connectCancellation, array $argv): void
-{
-    EventLoop::queue(function () use ($argv, $uri, $key, $connectCancellation): void {
+function runContext(
+    string $uri,
+    string $key,
+    Cancellation $connectCancellation,
+    array $argv,
+    Serializer $serializer = new NativeSerializer(),
+): void {
+    EventLoop::queue(function () use ($argv, $uri, $key, $connectCancellation, $serializer): void {
         /** @noinspection PhpUnusedLocalVariableInspection */
         $argc = \count($argv);
 
         try {
             $socket = Ipc\connect($uri, $key, $connectCancellation);
-            $ipcChannel = new StreamChannel($socket, $socket);
+            $ipcChannel = new StreamChannel($socket, $socket, $serializer);
 
             $socket = Ipc\connect($uri, $key, $connectCancellation);
-            $resultChannel = new StreamChannel($socket, $socket);
+            $resultChannel = new StreamChannel($socket, $socket, $serializer);
         } catch (\Throwable $exception) {
             \trigger_error($exception->getMessage(), E_USER_ERROR);
         }

--- a/src/Context/Internal/functions.php
+++ b/src/Context/Internal/functions.php
@@ -9,7 +9,6 @@ use Amp\Parallel\Ipc;
 use Amp\Serialization\NativeSerializer;
 use Amp\Serialization\SerializationException;
 use Amp\Serialization\Serializer;
-use Revolt\EventLoop;
 
 /** @internal */
 function runContext(
@@ -19,73 +18,69 @@ function runContext(
     array $argv,
     Serializer $serializer = new NativeSerializer(),
 ): void {
-    EventLoop::queue(function () use ($argv, $uri, $key, $connectCancellation, $serializer): void {
-        /** @noinspection PhpUnusedLocalVariableInspection */
-        $argc = \count($argv);
+    /** @noinspection PhpUnusedLocalVariableInspection */
+    $argc = \count($argv);
 
-        try {
-            $socket = Ipc\connect($uri, $key, $connectCancellation);
-            $ipcChannel = new StreamChannel($socket, $socket, $serializer);
+    try {
+        $socket = Ipc\connect($uri, $key, $connectCancellation);
+        $ipcChannel = new StreamChannel($socket, $socket, $serializer);
 
-            $socket = Ipc\connect($uri, $key, $connectCancellation);
-            $resultChannel = new StreamChannel($socket, $socket, $serializer);
-        } catch (\Throwable $exception) {
-            \trigger_error($exception->getMessage(), E_USER_ERROR);
+        $socket = Ipc\connect($uri, $key, $connectCancellation);
+        $resultChannel = new StreamChannel($socket, $socket, $serializer);
+    } catch (\Throwable $exception) {
+        \trigger_error($exception->getMessage(), E_USER_ERROR);
+    }
+
+    try {
+        if (!isset($argv[0])) {
+            throw new \Error("No script path given");
+        }
+
+        if (!\is_file($argv[0])) {
+            throw new \Error(\sprintf(
+                "No script found at '%s' (be sure to provide the full path to the script)",
+                $argv[0],
+            ));
         }
 
         try {
-            if (!isset($argv[0])) {
-                throw new \Error("No script path given");
-            }
-
-            if (!\is_file($argv[0])) {
-                throw new \Error(\sprintf(
-                    "No script found at '%s' (be sure to provide the full path to the script)",
-                    $argv[0],
-                ));
-            }
-
-            try {
-                // Protect current scope by requiring script within another function.
-                // Using $argc, so it is available to the required script.
-                $callable = (function () use ($argc, $argv): callable {
-                    /** @psalm-suppress UnresolvableInclude */
-                    return require $argv[0];
-                })();
-            } catch (\TypeError $exception) {
-                throw new \Error(\sprintf(
-                    "Script '%s' did not return a callable function: %s",
-                    $argv[0],
-                    $exception->getMessage(),
-                ), 0, $exception);
-            } catch (\ParseError $exception) {
-                throw new \Error(\sprintf(
-                    "Script '%s' contains a parse error: %s",
-                    $argv[0],
-                    $exception->getMessage(),
-                ), 0, $exception);
-            }
-
-            $returnValue = $callable(new ContextChannel($ipcChannel));
-            $result = new ExitSuccess($returnValue instanceof Future ? $returnValue->await() : $returnValue);
-        } catch (\Throwable $exception) {
-            $result = new ExitFailure($exception);
-        }
-
-        try {
-            try {
-                $resultChannel->send($result);
-            } catch (SerializationException $exception) {
-                // Serializing the result failed. Send the reason why.
-                $resultChannel->send(new ExitFailure($exception));
-            }
-        } catch (\Throwable $exception) {
-            \trigger_error(\sprintf(
-                "Could not send result to parent: '%s'; be sure to shutdown the child before ending the parent",
+            // Protect current scope by requiring script within another function.
+            // Using $argc, so it is available to the required script.
+            $callable = (function () use ($argc, $argv): callable {
+                /** @psalm-suppress UnresolvableInclude */
+                return require $argv[0];
+            })();
+        } catch (\TypeError $exception) {
+            throw new \Error(\sprintf(
+                "Script '%s' did not return a callable function: %s",
+                $argv[0],
                 $exception->getMessage(),
-            ), E_USER_ERROR);
+            ), 0, $exception);
+        } catch (\ParseError $exception) {
+            throw new \Error(\sprintf(
+                "Script '%s' contains a parse error: %s",
+                $argv[0],
+                $exception->getMessage(),
+            ), 0, $exception);
         }
-    });
 
-    EventLoop::run();
+        $returnValue = $callable(new ContextChannel($ipcChannel));
+        $result = new ExitSuccess($returnValue instanceof Future ? $returnValue->await() : $returnValue);
+    } catch (\Throwable $exception) {
+        $result = new ExitFailure($exception);
+    }
+
+    try {
+        try {
+            $resultChannel->send($result);
+        } catch (SerializationException $exception) {
+            // Serializing the result failed. Send the reason why.
+            $resultChannel->send(new ExitFailure($exception));
+        }
+    } catch (\Throwable $exception) {
+        \trigger_error(\sprintf(
+            "Could not send result to parent: '%s'; be sure to shutdown the child before ending the parent",
+            $exception->getMessage(),
+        ), E_USER_ERROR);
+    }
 }

--- a/src/Context/Internal/functions.php
+++ b/src/Context/Internal/functions.php
@@ -8,8 +8,8 @@ use Amp\Future;
 use Amp\Parallel\Ipc;
 use Amp\Serialization\NativeSerializer;
 use Amp\Serialization\SerializationException;
-use Amp\Sync\ChannelException;
 use Amp\Serialization\Serializer;
+use Amp\Sync\ChannelException;
 
 /** @internal */
 function runContext(

--- a/src/Context/Internal/functions.php
+++ b/src/Context/Internal/functions.php
@@ -72,12 +72,16 @@ function runContext(
         $result = new ExitFailure($exception);
     }
 
+    $ipcChannel->close();
+
     try {
         try {
             $resultChannel->send($result);
         } catch (SerializationException $exception) {
             // Serializing the result failed. Send the reason why.
             $resultChannel->send(new ExitFailure($exception));
+        } finally {
+            $resultChannel->close();
         }
     } catch (ChannelException) {
         // The parent may have already closed the channel after reading

--- a/src/Context/Internal/process-runner.php
+++ b/src/Context/Internal/process-runner.php
@@ -85,5 +85,7 @@ if (\function_exists("cli_set_process_title")) {
         \trigger_error($exception->getMessage(), E_USER_ERROR);
     }
 
-    runContext($uri, $key, $cancellation, $argv);
+    EventLoop::queue(runContext(...), $uri, $key, $cancellation, $argv);
+
+    EventLoop::run();
 })();

--- a/src/Context/ProcessContext.php
+++ b/src/Context/ProcessContext.php
@@ -282,12 +282,12 @@ final class ProcessContext extends AbstractContext
      */
     public function join(?Cancellation $cancellation = null): mixed
     {
-        $data = $this->receiveExitResult($cancellation);
+        $result = $this->receiveExitResult($cancellation);
 
         $code = $this->process->join();
 
         try {
-            return $data->getResult();
+            return $result->getResult();
         } finally {
             if ($code !== 0) {
                 // If an ExitFailure throws above, the exception will be automatically attached as the previous

--- a/src/Context/ThreadContext.php
+++ b/src/Context/ThreadContext.php
@@ -104,7 +104,9 @@ final class ThreadContext extends AbstractContext
                 // such as select() will not be interrupted.
             }));
 
-            Internal\runContext($uri, $key, new TimeoutCancellation($connectTimeout), $argv);
+            EventLoop::queue(Internal\runContext(...), $uri, $key, new TimeoutCancellation($connectTimeout), $argv);
+
+            EventLoop::run();
 
             return 0;
             // @codeCoverageIgnoreEnd

--- a/src/Context/ThreadContext.php
+++ b/src/Context/ThreadContext.php
@@ -211,8 +211,6 @@ final class ThreadContext extends AbstractContext
     {
         $data = $this->receiveExitResult($cancellation);
 
-        $this->close();
-
         return $data->getResult();
     }
 }

--- a/src/Context/ThreadContext.php
+++ b/src/Context/ThreadContext.php
@@ -209,8 +209,8 @@ final class ThreadContext extends AbstractContext
 
     public function join(?Cancellation $cancellation = null): mixed
     {
-        $data = $this->receiveExitResult($cancellation);
+        $result = $this->receiveExitResult($cancellation);
 
-        return $data->getResult();
+        return $result->getResult();
     }
 }

--- a/test/Context/ForkContextTest.php
+++ b/test/Context/ForkContextTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Amp\Parallel\Test\Context;
+
+use Amp\Parallel\Context\Context;
+use Amp\Parallel\Context\ForkContextFactory;
+
+class ForkContextTest extends AbstractContextTest
+{
+    public function createContext(string|array $script): Context
+    {
+        if (!\function_exists('pcntl_fork')) {
+            $this->markTestSkipped('pcntl_fork required');
+        }
+
+        return (new ForkContextFactory())->start($script);
+    }
+
+    public function testThrowingProcessOnReceive(): void
+    {
+        // tmp
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testThrowingProcessOnSend(): void
+    {
+        // tmp
+        $this->expectNotToPerformAssertions();
+    }
+}

--- a/test/Context/ForkContextTest.php
+++ b/test/Context/ForkContextTest.php
@@ -3,14 +3,15 @@
 namespace Amp\Parallel\Test\Context;
 
 use Amp\Parallel\Context\Context;
+use Amp\Parallel\Context\ForkContext;
 use Amp\Parallel\Context\ForkContextFactory;
 
 class ForkContextTest extends AbstractContextTest
 {
     public function createContext(string|array $script): Context
     {
-        if (!\function_exists('pcntl_fork')) {
-            $this->markTestSkipped('pcntl_fork required');
+        if (!ForkContext::isSupported()) {
+            $this->markTestSkipped('Not supported on the current platform/driver');
         }
 
         return (new ForkContextFactory())->start($script);

--- a/test/Context/ForkContextTest.php
+++ b/test/Context/ForkContextTest.php
@@ -6,6 +6,10 @@ use Amp\Parallel\Context\Context;
 use Amp\Parallel\Context\ForkContext;
 use Amp\Parallel\Context\ForkContextFactory;
 
+/**
+ * @requires extension pcntl
+ * @requires extension posix
+ */
 class ForkContextTest extends AbstractContextTest
 {
     public function createContext(string|array $script): Context
@@ -15,23 +19,5 @@ class ForkContextTest extends AbstractContextTest
         }
 
         return (new ForkContextFactory())->start($script);
-    }
-
-    public function testThrowingProcessOnReceive(): void
-    {
-        // tmp
-        $this->expectNotToPerformAssertions();
-    }
-
-    public function testThrowingProcessOnSend(): void
-    {
-        // tmp
-        $this->expectNotToPerformAssertions();
-    }
-
-    public function testImmediateJoin(): void
-    {
-        // tmp
-        $this->expectNotToPerformAssertions();
     }
 }

--- a/test/Context/ForkContextTest.php
+++ b/test/Context/ForkContextTest.php
@@ -28,4 +28,10 @@ class ForkContextTest extends AbstractContextTest
         // tmp
         $this->expectNotToPerformAssertions();
     }
+
+    public function testImmediateJoin(): void
+    {
+        // tmp
+        $this->expectNotToPerformAssertions();
+    }
 }


### PR DESCRIPTION
This adds a `Context` implementation which uses `pcntl_fork` to create another process. This is a strategy which we abandoned some time ago due to the issues with copying parent context into a child, however there are particular case where that behavior can be advantageous.

This context is NOT added to `DefaultContextFactory`, and in fact has warnings against its use in the class docblock.

@danog Can you please check if this works for you in Psalm.