### PR TITLE
Avoid deprecated `SplObjectStorage::attach`

### DIFF
--- a/src/Worker/ContextWorkerPool.php
+++ b/src/Worker/ContextWorkerPool.php
@@ -256,7 +256,7 @@ final class ContextWorkerPool implements LimitedWorkerPool
                             throw new WorkerException('Worker factory did not create a viable worker');
                         }
 
-                        $workers->attach($worker, 0);
+                        $workers->offsetSet($worker, 0);
                         return $worker;
                     });
 


### PR DESCRIPTION
`SplObjectStorage::attach()` was deprecated with PHP 8.5[^1]. Its usage is replaced by `SplObjectStorage::offsetSet()`, which provides the same functionality.

[^1]: https://github.com/php/php-src/pull/19424