### PR TITLE
Use exit instead of E_USER_ERROR

### DIFF
--- a/src/Context/Internal/functions.php
+++ b/src/Context/Internal/functions.php
@@ -23,7 +23,8 @@ function runContext(string $uri, string $key, Cancellation $connectCancellation,
             $socket = Ipc\connect($uri, $key, $connectCancellation);
             $resultChannel = new StreamChannel($socket, $socket);
         } catch (\Throwable $exception) {
-            \trigger_error($exception->getMessage(), E_USER_ERROR);
+            \file_put_contents('php://stderr', $exception->getMessage(), \FILE_APPEND);
+            exit(255);
         }
 
         try {
@@ -73,10 +74,11 @@ function runContext(string $uri, string $key, Cancellation $connectCancellation,
                 $resultChannel->send(new ExitFailure($exception));
             }
         } catch (\Throwable $exception) {
-            \trigger_error(\sprintf(
+            \file_put_contents('php://stderr', \sprintf(
                 "Could not send result to parent: '%s'; be sure to shutdown the child before ending the parent",
                 $exception->getMessage(),
-            ), E_USER_ERROR);
+            ), \FILE_APPEND);
+            exit(255);
         }
     });
 

--- a/src/Context/Internal/process-runner.php
+++ b/src/Context/Internal/process-runner.php
@@ -35,10 +35,8 @@ if (\function_exists("cli_set_process_title")) {
     }
 
     if (!isset($autoloadPath)) {
-        \trigger_error(
-            "Could not locate autoload.php in any of the following files: " . \implode(", ", $paths),
-            E_USER_ERROR,
-        );
+        \file_put_contents('php://stderr', "Could not locate autoload.php in any of the following files: " . \implode(", ", $paths), \FILE_APPEND);
+        exit(255);
     }
 
     /** @psalm-suppress UnresolvableInclude */
@@ -58,15 +56,18 @@ if (\function_exists("cli_set_process_title")) {
     /** @var list<string> $argv */
 
     if (!isset($argv[1])) {
-        \trigger_error("No socket path provided", E_USER_ERROR);
+        \file_put_contents('php://stderr', "No socket path provided", \FILE_APPEND);
+        exit(255);
     }
 
     if (!isset($argv[2]) || !\is_numeric($argv[2])) {
-        \trigger_error("No key length provided", E_USER_ERROR);
+        \file_put_contents('php://stderr', "No key length provided", \FILE_APPEND);
+        exit(255);
     }
 
     if (!isset($argv[3]) || !\is_numeric($argv[3])) {
-        \trigger_error("No timeout provided", E_USER_ERROR);
+        \file_put_contents('php://stderr', "No timeout provided", \FILE_APPEND);
+        exit(255);
     }
 
     [, $uri, $length, $timeout] = $argv;
@@ -82,7 +83,8 @@ if (\function_exists("cli_set_process_title")) {
         $cancellation = new TimeoutCancellation($timeout);
         $key = Ipc\readKey(ByteStream\getStdin(), $cancellation, $length);
     } catch (\Throwable $exception) {
-        \trigger_error($exception->getMessage(), E_USER_ERROR);
+        \file_put_contents('php://stderr', $exception->getMessage(), \FILE_APPEND);
+        exit(255);
     }
 
     runContext($uri, $key, $cancellation, $argv);


### PR DESCRIPTION
> Passing E_USER_ERROR to trigger_error() is deprecated since 8.4, throw an exception or call exit with a string message instead

Fix #223 