### PR TITLE
Silently ignore result send failure during shutdown

### DIFF
--- a/src/Context/Internal/functions.php
+++ b/src/Context/Internal/functions.php
@@ -7,6 +7,7 @@ use Amp\Cancellation;
 use Amp\Future;
 use Amp\Parallel\Ipc;
 use Amp\Serialization\SerializationException;
+use Amp\Sync\ChannelException;
 use Revolt\EventLoop;
 
 /** @internal */
@@ -23,7 +24,8 @@ function runContext(string $uri, string $key, Cancellation $connectCancellation,
             $socket = Ipc\connect($uri, $key, $connectCancellation);
             $resultChannel = new StreamChannel($socket, $socket);
         } catch (\Throwable $exception) {
-            \trigger_error($exception->getMessage(), E_USER_ERROR);
+            \file_put_contents('php://stderr', $exception->getMessage(), \FILE_APPEND);
+            exit(255);
         }
 
         try {
@@ -72,11 +74,12 @@ function runContext(string $uri, string $key, Cancellation $connectCancellation,
                 // Serializing the result failed. Send the reason why.
                 $resultChannel->send(new ExitFailure($exception));
             }
+        } catch (ChannelException) {
+            // The parent may have already closed the channel after reading
+            // the result (e.g. during shutdown). Nothing left to do.
         } catch (\Throwable $exception) {
-            \trigger_error(\sprintf(
-                "Could not send result to parent: '%s'; be sure to shutdown the child before ending the parent",
-                $exception->getMessage(),
-            ), E_USER_ERROR);
+            \file_put_contents('php://stderr', $exception->getMessage(), \FILE_APPEND);
+            exit(255);
         }
     });
 

--- a/src/Context/Internal/process-runner.php
+++ b/src/Context/Internal/process-runner.php
@@ -35,10 +35,8 @@ if (\function_exists("cli_set_process_title")) {
     }
 
     if (!isset($autoloadPath)) {
-        \trigger_error(
-            "Could not locate autoload.php in any of the following files: " . \implode(", ", $paths),
-            E_USER_ERROR,
-        );
+        \file_put_contents('php://stderr', "Could not locate autoload.php in any of the following files: " . \implode(", ", $paths), \FILE_APPEND);
+        exit(255);
     }
 
     /** @psalm-suppress UnresolvableInclude */
@@ -58,15 +56,18 @@ if (\function_exists("cli_set_process_title")) {
     /** @var list<string> $argv */
 
     if (!isset($argv[1])) {
-        \trigger_error("No socket path provided", E_USER_ERROR);
+        \file_put_contents('php://stderr', "No socket path provided", \FILE_APPEND);
+        exit(255);
     }
 
     if (!isset($argv[2]) || !\is_numeric($argv[2])) {
-        \trigger_error("No key length provided", E_USER_ERROR);
+        \file_put_contents('php://stderr', "No key length provided", \FILE_APPEND);
+        exit(255);
     }
 
     if (!isset($argv[3]) || !\is_numeric($argv[3])) {
-        \trigger_error("No timeout provided", E_USER_ERROR);
+        \file_put_contents('php://stderr', "No timeout provided", \FILE_APPEND);
+        exit(255);
     }
 
     [, $uri, $length, $timeout] = $argv;
@@ -82,7 +83,8 @@ if (\function_exists("cli_set_process_title")) {
         $cancellation = new TimeoutCancellation($timeout);
         $key = Ipc\readKey(ByteStream\getStdin(), $cancellation, $length);
     } catch (\Throwable $exception) {
-        \trigger_error($exception->getMessage(), E_USER_ERROR);
+        \file_put_contents('php://stderr', $exception->getMessage(), \FILE_APPEND);
+        exit(255);
     }
 
     runContext($uri, $key, $cancellation, $argv);


### PR DESCRIPTION
Fix https://github.com/amphp/parallel/issues/223 (reconsidering #225).

Found while using amphp/parallel outside of an event-loop.

When the parent closes the channel before the child finishes sending its result (e.g. during `Worker::kill()`), the send throws. This is a normal condition during shutdown, not an error: the parent already moved on. The child exits naturally when the callback returns and `EventLoop::run()` completes.

The previous message caused unnecessary noise.

The rest is about `trigger_error(E_USER_ERROR)`: it's deprecated in PHP 8.4.